### PR TITLE
Fix invalid path to activity file

### DIFF
--- a/trackMe
+++ b/trackMe
@@ -535,7 +535,7 @@ sumProject()
 	PROJECT="$1"
 
 	for ACTIVITY in "$PROJECT"/*; do
-		sumActivity "$PROJECT/$ACTIVITY"
+		sumActivity "$ACTIVITY"
 	done
 }
 


### PR DESCRIPTION
when summarizing all activities in a project, the first part of the path was duplicated.